### PR TITLE
Fixed an issue in apicoverage.go that caused API endpoints to be wrongly marked as tested

### DIFF
--- a/test/e2e/apicoverage/apicoverage.go
+++ b/test/e2e/apicoverage/apicoverage.go
@@ -44,7 +44,7 @@ type apiData struct {
 
 type apiArray []apiData
 
-var reOpenapi = regexp.MustCompile(`({\S+})`)
+var reOpenapi = regexp.MustCompile(`({\S+?})`)
 
 func parseOpenAPI(openapi string) apiArray {
 	var swaggerSpec spec.Swagger
@@ -111,9 +111,11 @@ func parseAPILog(restlog string) apiArray {
 		}
 		method := strings.ToUpper(string(result[1]))
 		url := string(result[2])
+		url_parts := strings.Split(url, "?")
+
 		api := apiData{
 			Method: method,
-			URL:    url,
+			URL:    url_parts[0],
 		}
 		apisLog = append(apisLog, api)
 	}
@@ -140,7 +142,7 @@ func main() {
 	apisLogs := parseAPILog(*restLog)
 
 	for _, openapi := range apisOpenapi {
-		regURL := reOpenapi.ReplaceAllLiteralString(openapi.URL, `\S+`)
+		regURL := reOpenapi.ReplaceAllLiteralString(openapi.URL, `[^/\s]+`) + `$`
 		reg := regexp.MustCompile(regURL)
 		found = false
 		for _, log := range apisLogs {


### PR DESCRIPTION
Hello!
I tried running your API Coverage script and ran into an issue that leads to API endpoints being wrongly marked as covered. For instance, when running the script with [api.log](https://github.com/oomichi/kubernetes/files/1427596/api.log) file, the

`PUT /api/v1/namespaces/{namespace}/limitranges/{name}`

endpoint is matched by

`PUT https://192.168.99.100:8443/api/v1/namespaces/e2e-tests-configmap-n6h2v/configmaps/cm-test-opt-upd-c6f74b50-b284-11e7-a0de-b8ca3aab9b51`

request. This happens because `reOpenapi` regexp is greedy, so the whole `{namespace}/limitranges/{name}` part gets replaced with `\S+`. Also, when matching API endpoints with requests, `\S+` can consume other parts of the URL. For instance:

`GET /api/v1/proxy/nodes/{name}`

can be matched with

`GET https://192.168.99.100:8443/api/v1/proxy/nodes/minikube/logs/`